### PR TITLE
Potential fix for code scanning alert no. 781: Unsafe use of getResource

### DIFF
--- a/library/src/test/java/com/ibm/research/drl/dpt/processors/CSVFormatProcessorTest.java
+++ b/library/src/test/java/com/ibm/research/drl/dpt/processors/CSVFormatProcessorTest.java
@@ -252,7 +252,7 @@ public class CSVFormatProcessorTest {
 
     @Test
     public void testFirstN() throws Exception {
-        try (InputStream inputStream = this.getClass().getResourceAsStream("/random1.txt")) {
+        try (InputStream inputStream = CSVFormatProcessorTest.class.getResourceAsStream("/random1.txt")) {
 
             CSVFormatProcessor formatProcessor = new CSVFormatProcessor();
             Iterable<Record> records = formatProcessor.extractRecords(inputStream, new CSVDatasetOptions(false, ',', '"', false), 2);
@@ -274,7 +274,7 @@ public class CSVFormatProcessorTest {
     
     @Test
     public void testIdentifyStreamCSV() throws Exception {
-        try (InputStream inputStream = this.getClass().getResourceAsStream("/random1.txt")) {
+        try (InputStream inputStream = CSVFormatProcessorTest.class.getResourceAsStream("/random1.txt")) {
 
             IdentificationReport results = new CSVFormatProcessor().identifyTypesStream(inputStream, DataTypeFormat.CSV,
                     new CSVDatasetOptions(false, ',', '"', false), IdentifierFactory.defaultIdentifiers(),  -1);
@@ -287,7 +287,7 @@ public class CSVFormatProcessorTest {
     
     @Test
     public void testMaskStream() throws Exception {
-        try (InputStream inputStream = this.getClass().getResourceAsStream("/demo.csv");
+        try (InputStream inputStream = CSVFormatProcessorTest.class.getResourceAsStream("/demo.csv");
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             PrintStream output = new PrintStream(outputStream)) {
 


### PR DESCRIPTION
Potential fix for [https://github.com/IBM/data-privacy-toolkit/security/code-scanning/781](https://github.com/IBM/data-privacy-toolkit/security/code-scanning/781)

To fix the problem, we should replace the use of `this.getClass().getResourceAsStream()` with `CSVFormatProcessorTest.class.getResourceAsStream()`. This ensures that the resource lookup is always performed using the `CSVFormatProcessorTest` class, avoiding issues related to run-time types and class loaders.

- Change the calls to `this.getClass().getResourceAsStream()` to `CSVFormatProcessorTest.class.getResourceAsStream()` on lines 255, 277, and 290.
- No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
