### PR TITLE
Potential fix for code scanning alert no. 872: Unsafe use of getResource

### DIFF
--- a/library/src/test/java/com/ibm/research/drl/dpt/risk/EstimatedRiskTest.java
+++ b/library/src/test/java/com/ibm/research/drl/dpt/risk/EstimatedRiskTest.java
@@ -379,7 +379,7 @@ public class EstimatedRiskTest {
     @Test
     @Disabled
     public void testDump() throws Exception {
-        InputStream sample = this.getClass().getResourceAsStream("/florida_sample_0.01.txt");
+        InputStream sample = EstimatedRiskTest.class.getResourceAsStream("/florida_sample_0.01.txt");
         IPVDataset sampleDataset = IPVDataset.load(sample, false, ',', '"', false);
 
         System.out.println("loading done");


### PR DESCRIPTION
Potential fix for [https://github.com/IBM/data-privacy-toolkit/security/code-scanning/872](https://github.com/IBM/data-privacy-toolkit/security/code-scanning/872)

To fix the problem, we should replace the `this.getClass().getResourceAsStream()` call with `EstimatedRiskTest.class.getResourceAsStream()`. This ensures that the resource path is always interpreted in the context of the `EstimatedRiskTest` class, avoiding issues with subclasses in different packages or different class loaders.

- Change the method call on line 382 from `this.getClass().getResourceAsStream("/florida_sample_0.01.txt")` to `EstimatedRiskTest.class.getResourceAsStream("/florida_sample_0.01.txt")`.
- No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
